### PR TITLE
changed callback to include a label param for identifying different events

### DIFF
--- a/lib/angular-gridster.js
+++ b/lib/angular-gridster.js
@@ -16,6 +16,9 @@ angular.module('gridster', [])
    * instantiates to tell widgets what their initial size should be. This can be useful to dynamically resize
    * inner content when the grid size changes.
    *
+   * Finally, any time a widget is finished dragging, a `gridster-widget-dragged` event will be emitted on the scope.
+   * This event has no arguments.
+   * 
    * @element ANY
    * @requires gridster.js
    * @param {object} gridster An object which contains the base options for gridster.js.
@@ -30,18 +33,22 @@ angular.module('gridster', [])
 
         this.gridster = function(arg) {
           return gridster = arg || gridster;
-        }
+        };
 
-        this.serialize = function(fn, e, ui, $widget) {
-          fn($scope, { serialized: this.gridster().serialize() });
+        this.serialize = function(callback, e, ui, $widget) {
+          callback.fn($scope, { serialized: this.gridster().serialize() });
 
-          if ($widget) {
-            $widget.scope().$broadcast('gridster-widget-resized', {
-              height: this.gridster().resize_coords.data.height,
-              width: this.gridster().resize_coords.data.width
-            });
+          if ($widget || (callback.label === 'dragged' && ui.$player )) {
+            if (callback.label === 'resized') {
+              $widget.scope().$broadcast('gridster-widget-resized', {
+                height: this.gridster().resize_coords.data.height,
+                width: this.gridster().resize_coords.data.width
+              });
+            } else if (callback.label === 'dragged') {
+              ui.$player.scope().$broadcast('gridster-widget-dragged');
+            }
           }
-        }
+        };
       }],
       link: function(scope, element, attr, controller) {
         scope.$on('gridster-repeat-complete', function(e) {
@@ -54,20 +61,20 @@ angular.module('gridster', [])
           // to widgets and to invoke the changed function.
           var callback = $parse(attr.gridsterChanged);
           options.draggable = options.draggable || {};
-          options.draggable.stop = controller.serialize.bind(controller, callback);
+          options.draggable.stop = controller.serialize.bind(controller, { fn: callback, label: 'dragged' });
           options.resize = options.resize || {};
-          options.resize.stop = controller.serialize.bind(controller, callback);
+          options.resize.stop = controller.serialize.bind(controller, { fn: callback, label: 'resized' });
 
           // Create the gridster object in the DOM
           var gridster = element.gridster(options).data('gridster');
 
           // Override all methods that change grid state to call the serialize function after executing
-          ['add_widget', 'resize_widget', 'remove_widget', 'remove_all_widgets'].forEach(function(name) {
+          ['add_widget', 'on_stop_drag', 'resize_widget', 'remove_widget', 'remove_all_widgets'].forEach(function(name) {
             var fn = gridster[name];
             gridster[name] = function() {
               fn.apply(gridster, arguments);
-              controller.serialize(callback);
-            }
+              controller.serialize({ fn: callback });
+            };
           });
 
           // Disable dragging and resizing if editable is false. Default to true/editable.
@@ -90,7 +97,7 @@ angular.module('gridster', [])
           });
         });
       }
-    }
+    };
   }])
 
   /*

--- a/lib/angular-gridster.js
+++ b/lib/angular-gridster.js
@@ -14,10 +14,12 @@ angular.module('gridster', [])
    * widget's scope. This event will have a single argument which is an object. It has a height and a width
    * property indicating the new resized size of the widget. This event will also be emitted when the grid first
    * instantiates to tell widgets what their initial size should be. This can be useful to dynamically resize
-   * inner content when the grid size changes.
+   * inner content when the grid size changes. The event will also send the results of gridster.serialize(), which
+   * gives the position of all widgets on the grid. Detailed docs can be found here: http://gridster.net/#serialize_method
    *
    * Finally, any time a widget is finished dragging, a `gridster-widget-dragged` event will be emitted on the scope.
-   * This event has no arguments.
+   * This event will emit a gridster serialization with the positions of all of the elements on the grid, similar to
+   * the `gridster-widget-resized` event.
    * 
    * @element ANY
    * @requires gridster.js
@@ -42,10 +44,13 @@ angular.module('gridster', [])
             if (callback.label === 'resized') {
               $widget.scope().$broadcast('gridster-widget-resized', {
                 height: this.gridster().resize_coords.data.height,
-                width: this.gridster().resize_coords.data.width
+                width: this.gridster().resize_coords.data.width,
+                serialize: this.gridster().serialize()
               });
             } else if (callback.label === 'dragged') {
-              ui.$player.scope().$broadcast('gridster-widget-dragged');
+              ui.$player.scope().$broadcast('gridster-widget-dragged', {
+                serialize: this.gridster().serialize()
+              });
             }
           }
         };
@@ -92,7 +97,8 @@ angular.module('gridster', [])
             var $widget = $(el);
             $widget.scope().$broadcast('gridster-widget-resized', {
               height: $widget.height(),
-              width: $widget.width()
+              width: $widget.width(),
+              serialize: []
             });
           });
         });


### PR DESCRIPTION
Something that was missing from this was the ability to differentiate between different types of events (resize vs. drag), which have slightly different implementations in the underlying gridster API.

In the current implementation, a _resize_ event will fire the `serialize` method continuously, but the actual broadcast will be limited by the `if ($widget)`. A _dragged_ event will only fire on stop. This leads to some trickiness when attempting to have slightly different logic for handling dragging and resizing (controlling the number/frequency of AJAX requests sent, for example). This is a patch.

There are some open questions: `if ($widget || (callback.label === 'dragged' && ui.$player ))` is a bit of hack. `$widget` never comes into the arguments on that serialization function, which I imagine is due to differences in the implementation of the [`resize`](http://gridster.net/docs/files/src_jquery.gridster.js.html#l994) and [`drag`](http://gridster.net/docs/files/src_jquery.gridster.js.html#l964) stop methods. I don't really know how to fix that.

Comments appreciated!
